### PR TITLE
Add Compose navigation with bottom bar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation("androidx.compose.ui:ui:1.6.1")
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.1")
     implementation("androidx.compose.material3:material3:1.2.0")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.compose.material:material-icons-extended:1.6.1")
     implementation("androidx.work:work-runtime-ktx:2.9.0")
     implementation("androidx.room:room-runtime:2.7.0")
     kapt("androidx.room:room-compiler:2.7.0")

--- a/app/src/main/java/com/example/trackstack/MainActivity.kt
+++ b/app/src/main/java/com/example/trackstack/MainActivity.kt
@@ -3,11 +3,28 @@ package com.example.trackstack
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.material3.Icon
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -20,9 +37,21 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun TrackStackApp() {
+    val navController = rememberNavController()
     MaterialTheme {
-        Surface {
-            Greeting()
+        Scaffold(
+            bottomBar = { BottomNavBar(navController) }
+        ) { innerPadding ->
+            NavHost(
+                navController = navController,
+                startDestination = Screen.Calendar.route,
+                modifier = Modifier.padding(innerPadding)
+            ) {
+                composable(Screen.Calendar.route) { CalendarScreen() }
+                composable(Screen.TemplateLibrary.route) { TemplateLibraryScreen() }
+                composable(Screen.Stats.route) { StatsScreen() }
+                composable(Screen.Settings.route) { SettingsScreen() }
+            }
         }
     }
 }
@@ -36,4 +65,63 @@ fun Greeting() {
 @Composable
 fun GreetingPreview() {
     TrackStackApp()
+}
+
+sealed class Screen(val route: String, val icon: ImageVector, val label: String) {
+    object Calendar : Screen("calendar", Icons.Filled.Home, "Calendar")
+    object TemplateLibrary : Screen("templates", Icons.Filled.List, "Templates")
+    object Stats : Screen("stats", Icons.Filled.ShowChart, "Stats")
+    object Settings : Screen("settings", Icons.Filled.Settings, "Settings")
+}
+
+@Composable
+fun BottomNavBar(navController: androidx.navigation.NavHostController) {
+    val items = listOf(
+        Screen.Calendar,
+        Screen.TemplateLibrary,
+        Screen.Stats,
+        Screen.Settings
+    )
+    NavigationBar {
+        val navBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute = navBackStackEntry?.destination?.route
+        items.forEach { screen ->
+            NavigationBarItem(
+                selected = currentRoute == screen.route,
+                onClick = {
+                    if (currentRoute != screen.route) {
+                        navController.navigate(screen.route) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                },
+                icon = { Icon(screen.icon, contentDescription = screen.label) },
+                label = { Text(screen.label) }
+            )
+        }
+    }
+}
+
+@Composable
+fun CalendarScreen() {
+    Surface { Text("Calendar Screen") }
+}
+
+@Composable
+fun TemplateLibraryScreen() {
+    Surface { Text("Template Library Screen") }
+}
+
+@Composable
+fun StatsScreen() {
+    Surface { Text("Stats Screen") }
+}
+
+@Composable
+fun SettingsScreen() {
+    Surface { Text("Settings Screen") }
 }


### PR DESCRIPTION
## Summary
- add navigation and icons dependencies
- implement `TrackStackApp` with a BottomNavigationBar
- create simple screen composables for calendar, template library, stats, and settings

## Testing
- `gradle :app:assembleDebug` *(fails: Plugin [id: 'dagger.hilt.android.plugin', version: '2.51'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764645d578832d93dcdebeb90900a2