### PR TITLE
Implement basic calendar and day detail UI

### DIFF
--- a/app/src/main/java/com/example/trackstack/CalendarScreen.kt
+++ b/app/src/main/java/com/example/trackstack/CalendarScreen.kt
@@ -1,0 +1,159 @@
+package com.example.trackstack
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import nl.dionsegijn.konfetti.compose.KonfettiView
+import nl.dionsegijn.konfetti.compose.models.Party
+import nl.dionsegijn.konfetti.compose.models.Emitter
+import nl.dionsegijn.konfetti.compose.models.Position
+import java.util.concurrent.TimeUnit
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
+
+/** Simple routine item kept in memory. */
+data class RoutineItem(
+    val id: Long,
+    val title: String,
+    val amPm: Int,
+    var completed: Boolean = false
+)
+
+data class DayInfo(
+    val date: LocalDate,
+    val routines: MutableList<RoutineItem> = mutableListOf(),
+    var hasCompetition: Boolean = false
+)
+
+@Composable
+fun CalendarScreen() {
+    val month = YearMonth.now()
+    val firstDay = month.atDay(1)
+    val monthDays = remember(month) {
+        (1..month.lengthOfMonth()).map { firstDay.plusDays((it - 1).toLong()) }
+    }
+    val startOffset = firstDay.dayOfWeek.ordinal % 7
+    val cells = List(startOffset) { null } + monthDays
+
+    val dayMap = remember { mutableStateMapOf<LocalDate, DayInfo>() }
+    var selectedDay by remember { mutableStateOf<DayInfo?>(null) }
+
+    Box {
+        Column {
+            Text(
+                month.month.getDisplayName(TextStyle.FULL, Locale.getDefault()),
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(16.dp)
+            )
+            LazyVerticalGrid(columns = GridCells.Fixed(7)) {
+                items(cells) { date ->
+                    if (date == null) {
+                        Box(modifier = Modifier.size(48.dp))
+                    } else {
+                        val info = dayMap.getOrPut(date) { DayInfo(date) }
+                        DayCell(info) { selectedDay = info }
+                    }
+                }
+            }
+        }
+        selectedDay?.let { info ->
+            DayDetailBottomSheet(
+                info = info,
+                onDismiss = { selectedDay = null }
+            )
+        }
+    }
+}
+
+@Composable
+private fun DayCell(info: DayInfo, onClick: () -> Unit) {
+    val completion = if (info.routines.isEmpty()) 0 else 100 * info.routines.count { it.completed } / info.routines.size
+    val color = if (completion == 100) Color(0xFF81C784) else Color(0xFFB0B0B0)
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .padding(2.dp)
+            .background(color)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = info.date.dayOfMonth.toString(), fontSize = 12.sp)
+        if (info.hasCompetition) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(8.dp)
+                    .background(Color(0xFF9C27B0), shape = MaterialTheme.shapes.small)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DayDetailBottomSheet(info: DayInfo, onDismiss: () -> Unit) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
+            Text("${info.date}", fontWeight = FontWeight.Bold)
+            val routines = remember(info) { info.routines }
+            routines.forEach { routine ->
+                val dismissState = rememberDismissState(
+                    confirmValueChange = {
+                        if (it == DismissValue.DismissedToStart) {
+                            routines.remove(routine)
+                            true
+                        } else false
+                    }
+                )
+                SwipeToDismiss(
+                    state = dismissState,
+                    background = {},
+                    dismissContent = {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth().padding(4.dp)
+                        ) {
+                            Checkbox(
+                                checked = routine.completed,
+                                onCheckedChange = { checked -> routine.completed = checked }
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(routine.title)
+                        }
+                    }
+                )
+            }
+            if (routines.isNotEmpty() && routines.all { it.completed }) {
+                KonfettiView(
+                    modifier = Modifier.fillMaxSize(),
+                    parties = listOf(
+                        Party(
+                            speed = 5f,
+                            maxSpeed = 30f,
+                            damping = 0.9f,
+                            spread = 360,
+                            colors = listOf(0xfff44336.toInt(), 0xff4caf50.toInt(), 0xff2196f3.toInt()),
+                            emitter = Emitter(duration = 100L, TimeUnit.MILLISECONDS).perSecond(50),
+                            position = Position.Relative(0.5, 0.0)
+                        )
+                    )
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/trackstack/MainActivity.kt
+++ b/app/src/main/java/com/example/trackstack/MainActivity.kt
@@ -108,10 +108,6 @@ fun BottomNavBar(navController: androidx.navigation.NavHostController) {
     }
 }
 
-@Composable
-fun CalendarScreen() {
-    Surface { Text("Calendar Screen") }
-}
 
 @Composable
 fun StatsScreen() {


### PR DESCRIPTION
## Summary
- add `CalendarScreen` with monthly grid and color-coded days
- show day routines in `DayDetailBottomSheet` with checkbox completion, swipe-to-delete and Konfetti
- hook up new screen from `MainActivity`

## Testing
- `gradle assembleDebug` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764ed6c0d0832da0557064a48a85db