### PR TITLE
Add OpenTrack sync worker

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,4 +45,5 @@ dependencies {
     implementation("com.github.DanielMartinus:Konfetti:2.0.0")
     implementation("com.google.accompanist:accompanist-reorderable:0.35.0")
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.1")
+    implementation(project(":openTrack"))
 }

--- a/app/src/main/java/com/example/trackstack/TrackStackApplication.kt
+++ b/app/src/main/java/com/example/trackstack/TrackStackApplication.kt
@@ -1,7 +1,13 @@
 package com.example.trackstack
 
 import android.app.Application
+import com.example.opentrack.SyncCompetitionsWorker
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class TrackStackApplication : Application()
+class TrackStackApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        SyncCompetitionsWorker.schedule(this)
+    }
+}

--- a/data/src/main/java/com/example/data/Repository.kt
+++ b/data/src/main/java/com/example/data/Repository.kt
@@ -1,18 +1,26 @@
 package com.example.data
 
+import com.example.data.entity.Competition
 import com.example.data.entity.DayRoutine
 import com.example.data.entity.Routine
 import com.example.data.entity.TrainingPeriod
+import java.time.LocalDate
 import javax.inject.Inject
 
 class Repository @Inject constructor(db: TrackStackDatabase) {
     private val routineDao = db.routineDao()
     private val periodDao = db.trainingPeriodDao()
     private val dayRoutineDao = db.dayRoutineDao()
+    private val competitionDao = db.competitionDao()
 
     suspend fun getAllRoutines(): List<Routine> = routineDao.getAll()
     suspend fun insertRoutine(routine: Routine) = routineDao.insert(routine)
     suspend fun getTrainingPeriods(): List<TrainingPeriod> = periodDao.getAll()
     suspend fun insertTrainingPeriod(period: TrainingPeriod) = periodDao.insert(period)
     suspend fun upsertDayRoutine(dayRoutine: DayRoutine) = dayRoutineDao.upsert(dayRoutine)
+
+    suspend fun upsertCompetitions(items: List<Competition>) = competitionDao.upsertAll(items)
+
+    suspend fun getUpcomingCompetitions(fromDate: LocalDate = LocalDate.now()): List<Competition> =
+        competitionDao.getUpcoming(fromDate)
 }

--- a/data/src/main/java/com/example/data/Settings.kt
+++ b/data/src/main/java/com/example/data/Settings.kt
@@ -1,0 +1,17 @@
+package com.example.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class Settings @Inject constructor(@ApplicationContext context: Context) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+
+    var athleteId: Long
+        get() = prefs.getLong("athlete_id", 0L)
+        set(value) { prefs.edit().putLong("athlete_id", value).apply() }
+}

--- a/data/src/main/java/com/example/data/TrackStackDatabase.kt
+++ b/data/src/main/java/com/example/data/TrackStackDatabase.kt
@@ -3,16 +3,18 @@ package com.example.data
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.example.data.dao.CompetitionDao
 import com.example.data.dao.DayRoutineDao
 import com.example.data.dao.RoutineDao
 import com.example.data.dao.TrainingPeriodDao
 import com.example.data.entity.Converters
+import com.example.data.entity.Competition
 import com.example.data.entity.DayRoutine
 import com.example.data.entity.Routine
 import com.example.data.entity.TrainingPeriod
 
 @Database(
-    entities = [Routine::class, TrainingPeriod::class, DayRoutine::class],
+    entities = [Routine::class, TrainingPeriod::class, DayRoutine::class, Competition::class],
     version = 1
 )
 @TypeConverters(Converters::class)
@@ -20,4 +22,5 @@ abstract class TrackStackDatabase : RoomDatabase() {
     abstract fun routineDao(): RoutineDao
     abstract fun trainingPeriodDao(): TrainingPeriodDao
     abstract fun dayRoutineDao(): DayRoutineDao
+    abstract fun competitionDao(): CompetitionDao
 }

--- a/data/src/main/java/com/example/data/dao/CompetitionDao.kt
+++ b/data/src/main/java/com/example/data/dao/CompetitionDao.kt
@@ -1,0 +1,17 @@
+package com.example.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.data.entity.Competition
+import java.time.LocalDate
+
+@Dao
+interface CompetitionDao {
+    @Query("SELECT * FROM Competition WHERE date >= :fromDate ORDER BY date")
+    suspend fun getUpcoming(fromDate: LocalDate): List<Competition>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(items: List<Competition>)
+}

--- a/data/src/main/java/com/example/data/di/DataModule.kt
+++ b/data/src/main/java/com/example/data/di/DataModule.kt
@@ -3,6 +3,7 @@ package com.example.data.di
 import android.content.Context
 import androidx.room.Room
 import com.example.data.Repository
+import com.example.data.Settings
 import com.example.data.TrackStackDatabase
 import dagger.Module
 import dagger.Provides
@@ -27,4 +28,8 @@ object DataModule {
     @Provides
     @Singleton
     fun provideRepository(db: TrackStackDatabase): Repository = Repository(db)
+
+    @Provides
+    @Singleton
+    fun provideSettings(@ApplicationContext context: Context): Settings = Settings(context)
 }

--- a/data/src/main/java/com/example/data/entity/Competition.kt
+++ b/data/src/main/java/com/example/data/entity/Competition.kt
@@ -1,0 +1,13 @@
+package com.example.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.time.LocalDate
+
+@Entity
+data class Competition(
+    @PrimaryKey val id: Long,
+    val name: String,
+    val date: LocalDate,
+    val city: String
+)

--- a/openTrack/build.gradle.kts
+++ b/openTrack/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
+android {
+    namespace = "com.example.opentrack"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.11.0")
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+    implementation("com.google.dagger:hilt-android:2.51")
+    kapt("com.google.dagger:hilt-compiler:2.51")
+    implementation(project(":data"))
+}

--- a/openTrack/src/main/java/com/example/opentrack/OpenTrackService.kt
+++ b/openTrack/src/main/java/com/example/opentrack/OpenTrackService.kt
@@ -1,0 +1,13 @@
+package com.example.opentrack
+
+import com.example.data.entity.Competition
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface OpenTrackService {
+    @GET("/api/v1/competitions")
+    suspend fun getCompetitions(
+        @Query("athlete_id") athleteId: Long,
+        @Query("from_date") fromDate: String = "2025-01-01"
+    ): List<Competition>
+}

--- a/openTrack/src/main/java/com/example/opentrack/SyncCompetitionsWorker.kt
+++ b/openTrack/src/main/java/com/example/opentrack/SyncCompetitionsWorker.kt
@@ -1,0 +1,44 @@
+package com.example.opentrack
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.example.data.Repository
+import com.example.data.Settings
+import java.util.concurrent.TimeUnit
+
+class SyncCompetitionsWorker(
+    appContext: Context,
+    params: WorkerParameters,
+    private val settings: Settings,
+    private val service: OpenTrackService,
+    private val repository: Repository
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            val id = settings.athleteId
+            val competitions = service.getCompetitions(id)
+            repository.upsertCompetitions(competitions)
+            Result.success()
+        } catch (e: Exception) {
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val WORK_NAME = "sync_competitions"
+
+        fun schedule(context: Context) {
+            val request = PeriodicWorkRequestBuilder<SyncCompetitionsWorker>(12, TimeUnit.HOURS).build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
+            )
+        }
+    }
+}

--- a/openTrack/src/main/java/com/example/opentrack/di/OpenTrackModule.kt
+++ b/openTrack/src/main/java/com/example/opentrack/di/OpenTrackModule.kt
@@ -1,0 +1,26 @@
+package com.example.opentrack.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+import com.example.opentrack.OpenTrackService
+
+@Module
+@InstallIn(SingletonComponent::class)
+object OpenTrackModule {
+    @Provides
+    @Singleton
+    fun provideRetrofit(): Retrofit = Retrofit.Builder()
+        .baseUrl("https://opentrack.run")
+        .addConverterFactory(MoshiConverterFactory.create())
+        .build()
+
+    @Provides
+    @Singleton
+    fun provideService(retrofit: Retrofit): OpenTrackService =
+        retrofit.create(OpenTrackService::class.java)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,3 +17,4 @@ rootProject.name = "TrackStack"
 include(":app")
 include(":data")
 include(":po10sync")
+include(":openTrack")


### PR DESCRIPTION
## Summary
- add `openTrack` module with Retrofit service and worker
- manage athlete id in new `Settings` class
- store competitions via new Room table and DAO
- expose upcoming competitions in repository
- trigger periodic sync from `TrackStackApplication`

## Testing
- `gradle build` *(fails: Plugin [id: 'dagger.hilt.android.plugin', version: '2.51'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765525b364832d8c6450f264c79ac9