### PR TITLE
Add Firebase Realtime Database

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     kotlin("android")
     kotlin("kapt")
     id("dagger.hilt.android.plugin") version "2.51"
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -46,4 +47,6 @@ dependencies {
     implementation("com.google.accompanist:accompanist-reorderable:0.35.0")
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.1")
     implementation(project(":openTrack"))
+    implementation(platform("com.google.firebase:firebase-bom:34.4.0"))
+    implementation("com.google.firebase:firebase-database-ktx")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ pluginManagement {
         id("org.jetbrains.kotlin.android") version "2.0.0"
         id("org.jetbrains.kotlin.kapt") version "2.0.0"
         id("dagger.hilt.android.plugin") version "2.51"
+        id("com.google.gms.google-services") version "4.4.1"
     }
 }
 


### PR DESCRIPTION
## Summary
- enable google services plugin
- add Firebase BOM
- add realtime database dependency
- configure plugin management for google services

## Testing
- `gradle -q help` *(fails: Plugin [id: 'dagger.hilt.android.plugin', version: '2.51'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876588ff268832da0d698e9c147cc4b