### PR TITLE
Implement stats screen with charts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     kapt("com.google.dagger:hilt-compiler:2.51")
     implementation("com.github.DanielMartinus:Konfetti:2.0.0")
     implementation("com.google.accompanist:accompanist-reorderable:0.35.0")
+    implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.1")
     implementation(project(":openTrack"))
     implementation(platform("com.google.firebase:firebase-bom:34.4.0"))

--- a/app/src/main/java/com/example/trackstack/MainActivity.kt
+++ b/app/src/main/java/com/example/trackstack/MainActivity.kt
@@ -110,11 +110,6 @@ fun BottomNavBar(navController: androidx.navigation.NavHostController) {
 
 
 @Composable
-fun StatsScreen() {
-    Surface { Text("Stats Screen") }
-}
-
-@Composable
 fun SettingsScreen() {
     Surface { Text("Settings Screen") }
 }

--- a/app/src/main/java/com/example/trackstack/StatsScreen.kt
+++ b/app/src/main/java/com/example/trackstack/StatsScreen.kt
@@ -1,0 +1,114 @@
+package com.example.trackstack
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.github.mikephil.charting.charts.BarChart
+import com.github.mikephil.charting.charts.LineChart
+import com.github.mikephil.charting.components.Description
+import com.github.mikephil.charting.data.BarData
+import com.github.mikephil.charting.data.BarDataSet
+import com.github.mikephil.charting.data.BarEntry
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.LineData
+import com.github.mikephil.charting.data.LineDataSet
+
+@Composable
+fun StatsScreen(viewModel: StatsViewModel = hiltViewModel()) {
+    val rankingDeltas by viewModel.rankingDeltas.collectAsState()
+    val scrollState = rememberScrollState()
+
+    Surface {
+        Column(Modifier.verticalScroll(scrollState).padding(16.dp)) {
+            Text("7-day Completion", style = MaterialTheme.typography.titleMedium)
+            LineChartView(viewModel.completionPercentages)
+
+            Spacer(Modifier.height(16.dp))
+
+            Text("Weekly Routine Counts", style = MaterialTheme.typography.titleMedium)
+            BarChartView(viewModel.categories, viewModel.weeklyCounts)
+
+            Spacer(Modifier.height(16.dp))
+
+            Text("Ranking Changes", style = MaterialTheme.typography.titleMedium)
+            rankingDeltas.forEach { delta ->
+                Text("${delta.event}: ${delta.newPos} (${delta.oldPos - delta.newPos})")
+            }
+        }
+    }
+}
+
+@Composable
+private fun LineChartView(values: List<Float>) {
+    val entries = remember(values) {
+        values.mapIndexed { index, v -> Entry(index.toFloat(), v) }
+    }
+    AndroidView(
+        factory = { context ->
+            LineChart(context).apply {
+                description = Description().apply { text = "" }
+                axisRight.isEnabled = false
+                data = LineData(LineDataSet(entries, "Completion %").apply {
+                    setDrawValues(false)
+                })
+                animateX(500)
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp)
+    ) { chart ->
+        chart.data.getDataSetByIndex(0).clear()
+        entries.forEach { chart.data.addEntry(it, 0) }
+        chart.data.notifyDataChanged()
+        chart.notifyDataSetChanged()
+    }
+}
+
+@Composable
+private fun BarChartView(categories: List<String>, weekly: List<FloatArray>) {
+    val entries = remember(weekly) {
+        weekly.mapIndexed { index, counts ->
+            BarEntry(index.toFloat(), counts)
+        }
+    }
+    val set = remember(categories) {
+        BarDataSet(entries, "Routines").apply {
+            setDrawValues(false)
+            setColors(*intArrayOf(0xFF90CAF9.toInt(), 0xFFA5D6A7.toInt(), 0xFFFFF59D.toInt()))
+            stackLabels = categories.toTypedArray()
+        }
+    }
+    AndroidView(
+        factory = { context ->
+            BarChart(context).apply {
+                description = Description().apply { text = "" }
+                axisRight.isEnabled = false
+                data = BarData(set)
+                animateY(500)
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp)
+    ) { chart ->
+        chart.data = BarData(set)
+        chart.invalidate()
+    }
+}
+

--- a/app/src/main/java/com/example/trackstack/StatsViewModel.kt
+++ b/app/src/main/java/com/example/trackstack/StatsViewModel.kt
@@ -1,0 +1,32 @@
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.data.RankingDelta
+import com.example.data.RankingDeltaSource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class StatsViewModel @Inject constructor(
+    rankingSource: RankingDeltaSource
+) : ViewModel() {
+
+    val rankingDeltas = rankingSource.rankingDeltas()
+        .scan(emptyList<RankingDelta>()) { acc, delta ->
+            (listOf(delta) + acc).take(5)
+        }
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    // Sample completion percentages for the last 14 days
+    val completionPercentages = List(14) { (60..100).random().toFloat() }
+
+    // Sample routine category counts per week
+    val categories = listOf("Run", "Strength", "Rest")
+    val weeklyCounts = listOf(
+        floatArrayOf(3f, 2f, 2f),
+        floatArrayOf(4f, 1f, 2f),
+        floatArrayOf(2f, 3f, 2f)
+    )
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,5 +6,6 @@ allprojects {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven("https://jitpack.io")
     }
 }


### PR DESCRIPTION
## Summary
- add JitPack repository
- add MPAndroidChart and hilt-navigation-compose to app module
- create `StatsViewModel` for sample chart and ranking data
- implement `StatsScreen` with MPAndroidChart line and stacked bar charts and ranking table
- hook new screen into `MainActivity`

## Testing
- `./gradlew assembleDebug` *(fails: gradle wrapper jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_687660ba037c832d97318ac2487a8c96