### PR TITLE
Update Kotlin to 2.1.10 with Compose plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("com.android.application")
     kotlin("android")
     kotlin("kapt")
-    kotlin("plugin.compose")
     id("com.google.dagger.hilt.android")
     id("com.google.gms.google-services")
     id("org.jetbrains.kotlin.plugin.compose")
@@ -34,6 +33,7 @@ android {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.1.10"))
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.activity:activity-compose:1.9.0")

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -22,6 +22,7 @@ android {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.1.10"))
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.room:room-runtime:2.7.0")
     implementation("androidx.room:room-ktx:2.7.0")

--- a/openTrack/build.gradle.kts
+++ b/openTrack/build.gradle.kts
@@ -21,6 +21,7 @@ android {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.1.10"))
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("com.squareup.retrofit2:retrofit:2.11.0")
     implementation("com.squareup.retrofit2:converter-moshi:2.11.0")


### PR DESCRIPTION
## Summary
- use Kotlin 2.1.10 and Jetpack Compose plugin
- update Material3 to latest alpha and add Kotlin BOM
- align module compile options with JVM 17

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d033a7e0832d85da7e5d27deaecc